### PR TITLE
 - add `Config.Grid.TopView.backgroundColor` to make topView backgrou…

### DIFF
--- a/Sources/Utils/Config.swift
+++ b/Sources/Utils/Config.swift
@@ -69,6 +69,10 @@ public struct Config {
       public static var borderColor: UIColor = UIColor(red: 0, green: 239/255, blue: 155/255, alpha: 1)
     }
 
+    public struct TopView {
+      public static var backgroundColor: UIColor = UIColor.white
+    }
+
     struct Dimension {
       static let columnCount: CGFloat = 4
       static let cellSpacing: CGFloat = 2
@@ -88,6 +92,10 @@ public struct Config {
       public static var textColor: UIColor = UIColor.white
       public static var highlightedTextColor: UIColor = UIColor.lightGray
       public static var backgroundColor = UIColor(red: 40/255, green: 170/255, blue: 236/255, alpha: 1)
+    }
+
+    public struct CloseButton {
+      public static var tintColor: UIColor = UIColor(red: 109/255, green: 107/255, blue: 132/255, alpha: 1)
     }
   }
 

--- a/Sources/Utils/Pages/PagesController.swift
+++ b/Sources/Utils/Pages/PagesController.swift
@@ -32,7 +32,7 @@ class PagesController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    view.backgroundColor = .black
+    view.backgroundColor = Config.PageIndicator.backgroundColor
     setup()
   }
 

--- a/Sources/Utils/Permission/PermissionView.swift
+++ b/Sources/Utils/Permission/PermissionView.swift
@@ -28,7 +28,7 @@ class PermissionView: UIView {
       addSubview($0)
     }
 
-    closeButton.g_pin(on: .top)
+    closeButton.g_pin(on: .top, constant: UIApplication.shared.statusBarFrame.height)
     closeButton.g_pin(on: .left)
     closeButton.g_pin(size: CGSize(width: 44, height: 44))
 
@@ -77,7 +77,7 @@ class PermissionView: UIView {
   func makeCloseButton() -> UIButton {
     let button = UIButton(type: .custom)
     button.setImage(GalleryBundle.image("gallery_close")?.withRenderingMode(.alwaysTemplate), for: UIControl.State())
-    button.tintColor = Config.Grid.CloseButton.tintColor
+    button.tintColor = Config.Permission.CloseButton.tintColor
 
     return button
   }

--- a/Sources/Utils/View/GridView.swift
+++ b/Sources/Utils/View/GridView.swift
@@ -43,24 +43,20 @@ class GridView: UIView {
         bottomView.addSubview($0)
     }
 
+    var safeAreaInsetTop: CGFloat = 0
+    if #available(iOS 11, *) {
+      safeAreaInsetTop = UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0
+    }
+
     Constraint.on(
       topView.leftAnchor.constraint(equalTo: topView.superview!.leftAnchor),
       topView.rightAnchor.constraint(equalTo: topView.superview!.rightAnchor),
-      topView.heightAnchor.constraint(equalToConstant: 40),
+      topView.topAnchor.constraint(equalTo: topView.superview!.topAnchor),
+      topView.heightAnchor.constraint(equalToConstant: 40 + safeAreaInsetTop),
 
       loadingIndicator.centerXAnchor.constraint(equalTo: loadingIndicator.superview!.centerXAnchor),
       loadingIndicator.centerYAnchor.constraint(equalTo: loadingIndicator.superview!.centerYAnchor)
     )
-
-    if #available(iOS 11, *) {
-      Constraint.on(
-        topView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor)
-      )
-    } else {
-      Constraint.on(
-        topView.topAnchor.constraint(equalTo: topView.superview!.topAnchor)
-      )
-    }
 
     bottomView.g_pinDownward()
     bottomView.g_pin(height: 80)
@@ -72,11 +68,12 @@ class GridView: UIView {
 
     bottomBlurView.g_pinEdges()
 
-    closeButton.g_pin(on: .top)
+    closeButton.g_pin(on: .top, constant: safeAreaInsetTop)
     closeButton.g_pin(on: .left)
     closeButton.g_pin(size: CGSize(width: 40, height: 40))
 
-    arrowButton.g_pinCenter()
+    arrowButton.g_pin(on: .centerX)
+    arrowButton.g_pin(on: .top, constant: safeAreaInsetTop)
     arrowButton.g_pin(height: 40)
 
     doneButton.g_pin(on: .centerY)
@@ -87,7 +84,7 @@ class GridView: UIView {
 
   private func makeTopView() -> UIView {
     let view = UIView()
-    view.backgroundColor = UIColor.white
+    view.backgroundColor = Config.Grid.TopView.backgroundColor
 
     return view
   }


### PR DESCRIPTION
…ndColor configurable

 - add `Config.Permission.CloseButton.tintColor` to separate tintColor from grid config
 - use `Config.PageIndicator.backgroundColor` as `PagesController` backgroundColor
 - offset `PermissionView.closeButton` by statusBar height to improve positioning on devices with "notch"