### PR TITLE
Allow smoother Single image selection

### DIFF
--- a/Sources/Images/ImagesController.swift
+++ b/Sources/Images/ImagesController.swift
@@ -224,6 +224,13 @@ extension ImagesController: UICollectionViewDataSource, UICollectionViewDelegate
     if cart.images.contains(item) {
       cart.remove(item)
     } else {
+      // In single image selection mode, remove selected image when
+      // another image is clicked
+      if Config.Camera.imageLimit == 1 && cart.images.count == 1
+      {
+          cart.remove(cart.images[0])
+      }
+
       if Config.Camera.imageLimit == 0 || Config.Camera.imageLimit > cart.images.count{
         cart.add(item)
       }


### PR DESCRIPTION
when a single image selection mode is selected (by setting imageLimit to 1) the controller doesn't select the image until the user manually deselects the previous one, this modification automatically removes the last picked image to allow for the new image to be selected in single image selection mode.